### PR TITLE
Fix | Link profile changing types with server's

### DIFF
--- a/src/api/resolvers/user/dto/output/update-user-output.dto.ts
+++ b/src/api/resolvers/user/dto/output/update-user-output.dto.ts
@@ -3,8 +3,8 @@ import type { UserSex } from '../../../../../utils/userState/UserState.types.ts'
 export interface UpdateUserOutputDto {
   id?: number;
   updatedData?: {
-    username?: string | undefined;
-    birth?: string | undefined;
-    sex?: UserSex | undefined;
+    username?: string;
+    age?: Date;
+    gender?: UserSex;
   };
 }

--- a/src/pages/PersonalAccountChanging.vue
+++ b/src/pages/PersonalAccountChanging.vue
@@ -13,8 +13,8 @@ const updateProfile = async () => {
     id: UserState.id,
     updatedData: {
       username: UserState.username,
-      birth: UserState.birth,
-      sex: UserState.sex
+      age: UserState.age ? new Date(UserState.age) : undefined,
+      gender: UserState.gender
     }
   }).then(res => {
     if (res.status == 200) {
@@ -43,19 +43,19 @@ const updateProfile = async () => {
         <h3>Дата Рождения</h3>
         <CustomInput
             type="date"
-            v-model="UserState.birth"
+            v-model="UserState.age"
         />
       </div>
       <div class="field sex">
         <h3>Пол</h3>
         <div class="radios">
           <input
-              :checked="UserState.sex == 'MALE'"
+              :checked="UserState.gender == 'MALE'"
               type="radio"
               name="sex"
-              value="male"
+              value="MALE"
               id="input-sex-male"
-              v-model="UserState.sex"
+              v-model="UserState.gender"
           >
           <div class="radio-sex">
             <label for="input-sex-male">
@@ -63,12 +63,12 @@ const updateProfile = async () => {
             </label>
           </div>
           <input
-              :checked="UserState.sex == 'FEMALE'"
+              :checked="UserState.gender == 'FEMALE'"
               type="radio"
               name="sex"
-              value="female"
+              value="FEMALE"
               id="input-sex-female"
-              v-model="UserState.sex"
+              v-model="UserState.gender"
           >
           <div class="radio-sex">
             <label for="input-sex-female">

--- a/src/utils/userState/UserState.ts
+++ b/src/utils/userState/UserState.ts
@@ -15,8 +15,8 @@ interface UserJwt {
   username: string;
   email: string;
   role: UserRole;
-  birth: string;
-  sex: UserSex;
+  age: string;
+  gender: UserSex;
   isBanned: boolean;
   iat: number;
   exp: number;
@@ -33,8 +33,8 @@ export const updateUserState = () => {
       UserState.status = 'authorized';
       UserState.username = userData.username;
       UserState.email = userData.email;
-      UserState.birth = userData.birth;
-      UserState.sex = userData.sex;
+      UserState.age = userData.age;
+      UserState.gender = userData.gender;
 
       if (userData.role) {
         UserState.role = userData.role;

--- a/src/utils/userState/UserState.types.ts
+++ b/src/utils/userState/UserState.types.ts
@@ -37,12 +37,12 @@ export interface UserStateInterface {
   /**
    * User's age (for tests)
    */
-  birth?: string;
+  age?: string;
 
   /**
    * User's sex (for tests)
    */
-  sex?: UserSex | undefined;
+  gender?: UserSex;
 
   /**
    * User's role on website


### PR DESCRIPTION
We had different names for the same things:
- gender (server) & sex (client)
- age (server) & birth (client)

Now client property are similar to server's